### PR TITLE
Force mongoose 3.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^4.11.2",
     "jade": "^1.9.1",
     "method-override": "^2.3.1",
-    "mongoose": "^3.8.22",
+    "mongoose": "~3.8.22",
     "morgan": "^1.5.1",
     "multer": "^0.1.7",
     "sfacts": "0.0.9",


### PR DESCRIPTION
I encountered an Index error with the default package.json install of mongoose 3.9.7 (unstable) that was installed due to the caret version.  Forcing 3.8.x resolved the issue.

TypeError: Cannot read property 'length' of undefined
    at processResults (superscript-editor/node_modules/mongoose/node_modules/mongodb/lib/mongodb/db.js:1581:31)
