### PR TITLE
Adds missing winston module and require in config/express.js

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -6,12 +6,13 @@
 var express = require('express');
 var compression = require('compression');
 var morgan = require('morgan');
+var winston = require('winston');
 var cookieParser = require('cookie-parser');
 var cookieSession = require('cookie-session');
 var bodyParser = require('body-parser');
 var methodOverride = require('method-override');
 var csrf = require('csurf');
-var multer = require('multer'); 
+var multer = require('multer');
 
 var flash = require('connect-flash');
 var helpers = require('view-helpers');
@@ -72,7 +73,7 @@ module.exports = function (app) {
     return filename.replace(/\W+/g, '-').toLowerCase() + Date.now()
   }
 }))
-  
+
   app.use(methodOverride(function (req, res) {
     if (req.body && typeof req.body === 'object' && '_method' in req.body) {
       // look in urlencoded POST bodies and delete it
@@ -88,7 +89,7 @@ module.exports = function (app) {
   // cookieParser should be above session
   app.use(cookieParser());
   app.use(cookieSession({ secret: 'secret' }));
-  
+
   // connect flash for flash messages - should be declared after sessions
   app.use(flash());
 
@@ -96,7 +97,7 @@ module.exports = function (app) {
     res.locals.success_messages = req.flash('success');
     res.locals.error_messages = req.flash('error');
     next();
-  });  
+  });
 
   // should be declared after session and flash
   app.use(helpers(pkg.name));

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jade": "^1.9.1",
     "method-override": "^2.3.1",
     "mongoose": "~3.8.22",
+    "mongoose-findorcreate": "^0.1.2",
     "morgan": "^1.5.1",
     "multer": "^0.1.7",
     "sfacts": "0.0.9",
@@ -35,7 +36,7 @@
     "superscript": "latest",
     "underscore": "^1.7.0",
     "view-helpers": "^0.1.5",
-    "mongoose-findorcreate": "^0.1.2"
+    "winston": "^1.0.0"
   },
   "devDependencies": {
     "debug": "^2.1.2",


### PR DESCRIPTION
Simple addition for a missing winston logger which causes the editor to crash if NODE_ENV is not 'development'.

Note: The "insignificant" whitespace diffs are due to some settings I have in my editor to trim trailing whitespace and ensure newline at eof on save.
