### PR TITLE
pass env vars to slack client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ logs/*
 systemDB/*
 uploads/*
 plugins/wizard.js
+superscript-editor.iml
+.idea

--- a/controllers/dashboard.js
+++ b/controllers/dashboard.js
@@ -23,10 +23,13 @@ module.exports = function(models, bot, project) {
           item.save(function(err, result){
 
             if (req.body.start) {
-              var evars = {
-                'TOKEN': req.body.token,
-                'PROJECT': project
-              };
+              evars = {};
+              for(key in process.env) {
+                evars[key] = process.env[key];
+              }
+              evars.TOKEN = req.body.token;
+              evars.PROJECT = project;
+
               if (slackClient) {
                 req.flash('error', 'Slack Client Already Running');
                 res.redirect('back');


### PR DESCRIPTION
passing the env vars to the child process/slack client solves the issue where node cannot start (nvm / iojs)

```
stdout: 
stderr: /bin/sh: node: command not found

exec error: Error: Command failed: /bin/sh -c node ./lib/slack.js
/bin/sh: node: command not found
```
